### PR TITLE
Add 'feeling lucky' functionality to Explore feature

### DIFF
--- a/src/api-wrapper/explore/roadmap-card-data.ts
+++ b/src/api-wrapper/explore/roadmap-card-data.ts
@@ -42,3 +42,18 @@ export const fetchRoadmapCardsExplore = errorHandlerDecorator(
     return responseExplore.json();
   }
 );
+
+export type FeelingLuckyApi = {
+  success: boolean;
+  message: string;
+  data: number;
+};
+
+export async function fetchFeelingLucky() {
+    const fetchRouteExplore = `/api/search/feeling-lucky`;
+    const responseExplore = await fetch(fetchRouteExplore, {
+        method: 'GET',
+        credentials: 'include',
+    }).then((res) => res.json());
+    return responseExplore as FeelingLuckyApi;
+}

--- a/src/components/explore/UI/ExploreDesktop.tsx
+++ b/src/components/explore/UI/ExploreDesktop.tsx
@@ -17,6 +17,7 @@ import Pagination from '@components/explore/UI/components-desktop/paginations/Pa
 import { CardRoadmapTypeApi } from '@type/explore/card';
 import LoadingCard from '@components/explore/UI/shared/cards/LoadingCard';
 import { useExploreCardData } from '@components/explore/logic/hooks/useExploreCardData';
+import { fetchFeelingLucky } from '@src/api-wrapper/explore/roadmap-card-data';
 
 const ExploreDesktop = () => {
   const { cardData, params, perPage, sortBy, topic } = useExploreCardData();
@@ -63,10 +64,9 @@ const ExploreDesktop = () => {
               <button
                 type='button'
                 onClick={() => {
-                  setExploreQuery({
-                    query: '',
+                  fetchFeelingLucky().then((res) => {
+                    window.location.href = `/roadmap/${res.data}`;
                   });
-                  setExploreQueryTopic('all');
                 }}
                 className='py-1 px-3 border-2 border-primary font-roboto-text font-medium text-primary rounded-lg mb-6 hover:bg-primary hover:text-white transition-all'
               >


### PR DESCRIPTION
This commit adds a 'Feeling Lucky' feature to the Explore component. Instead of manually setting the explore query, the 'Feeling Lucky' button now makes a call to the newly created 'fetchFeelingLucky' function in the 'roadmap-card-data' API wrapper. This function fetches a random roadmap and redirects the user to it. This adds an element of surprise and spontaneity to the user experience.