### PR TITLE
Opacity refactor

### DIFF
--- a/src/to-be-organized/nodeview/ComponentsRenderer.tsx
+++ b/src/to-be-organized/nodeview/ComponentsRenderer.tsx
@@ -22,6 +22,7 @@ import editorSelectedData, {
   getSelectedNodeId,
 } from '@store/roadmap-refactor/elements-editing/editor-selected-data';
 import displayManagerStore from '@store/roadmap-refactor/display/display-manager';
+import { hexAddAlpha } from '@src/typescript/roadmap_ref/utils';
 
 type IComponentElementProps = {
   component: IComponentObject;
@@ -69,7 +70,7 @@ const ComponentRendererForeign = ({
         parentSelected ? 'pointer-events-auto' : 'pointer-events-none'
       } ${parentSelected && 'border-opacity-100'} transition-allNoTransform`}
       style={{
-        color: `${textColor.slice(0, -1)},${opacityFiltered})`,
+        color: `${hexAddAlpha(textColor, opacityFiltered)}`,
         fontSize: fontSizeSelect,
         fontWeight: textWeightSelect,
         textAlign: 'center',

--- a/src/to-be-organized/nodeview/NodeRendererForeign.tsx
+++ b/src/to-be-organized/nodeview/NodeRendererForeign.tsx
@@ -192,15 +192,12 @@ const NodeRendererForeign: React.FC<NodeViewProps> = ({
 
     const borderStyle =
       borderColor === '#none'
-        ? `2px solid ${hexAddAlpha(color, bgOpacity)}`
+        ? `2px solid transparent`
         : `2px solid ${hexAddAlpha(borderColor, bgOpacity)}`;
 
     const style = {
       // color: textColor,
-      backgroundColor: `rgba(${parseInt(color.slice(1, 3), 16)}, ${parseInt(
-        color.slice(3, 5),
-        16
-      )}, ${parseInt(color.slice(5, 7), 16)}, ${bgOpacity})`, // assuming color is in #RRGGBB format
+      backgroundColor: hexAddAlpha(color, bgOpacity),
       width,
       height,
       top: calculatedOffsetCoords.y + coords.y,

--- a/src/to-be-organized/nodeview/NodeRendererForeign.tsx
+++ b/src/to-be-organized/nodeview/NodeRendererForeign.tsx
@@ -56,6 +56,7 @@ import scaleSafariStore from '@store/roadmap-refactor/misc/scale-safari-store';
 import { useStateWithSideEffects } from '@hooks/useStateWithSideEffects';
 import { getRoadmapNodeProgress } from '@store/roadmap-refactor/roadmap-data/misc-data/roadmap-progress';
 import { getResize } from '@src/to-be-organized/resize-dragging/stores-resize-shared-data';
+import { hexAddAlpha } from '@src/typescript/roadmap_ref/utils';
 import { handleNotification } from './notification-handler';
 
 interface NodeViewProps {
@@ -190,12 +191,9 @@ const NodeRendererForeign: React.FC<NodeViewProps> = ({
       bgOpacity === 0 ? 'shadow-none' : isSubNode ? 'shadow-md' : 'shadow-lg';
 
     const borderStyle =
-      // eslint-disable-next-line no-nested-ternary
-      bgOpacity === 0
-        ? '2px solid transparent'
-        : borderColor === '#none'
-        ? `2px solid ${color}`
-        : `2px solid ${borderColor}`;
+      borderColor === '#none'
+        ? `2px solid ${hexAddAlpha(color, bgOpacity)}`
+        : `2px solid ${hexAddAlpha(borderColor, bgOpacity)}`;
 
     const style = {
       // color: textColor,

--- a/src/typescript/roadmap_ref/node/core/color-themes.ts
+++ b/src/typescript/roadmap_ref/node/core/color-themes.ts
@@ -4,25 +4,25 @@ export const colorThemes: IColorThemes = {
   winterTheme: {
     primary: {
       nodeColor: '#ffffff',
-      textColor: 'rgb(0,0,0)',
+      textColor: '#000000',
       borderColor: '#c5c5c5',
       defaultOpacity: 60,
     },
     secondary: {
       nodeColor: '#1A1B50',
-      textColor: 'rgb(255, 255, 255)',
+      textColor: '#FFFFFF',
       borderColor: '#none',
       defaultOpacity: 100,
     },
     tertiary: {
       nodeColor: '#3361D8',
-      textColor: 'rgb(255, 255, 255)',
+      textColor: '#FFFFFF',
       borderColor: '#none',
       defaultOpacity: 100,
     },
     Quaternary: {
       nodeColor: '#E3EDF6',
-      textColor: 'rgb(26,27,80)',
+      textColor: '#1A1B50',
       borderColor: '#none',
       defaultOpacity: 100,
     },
@@ -30,25 +30,25 @@ export const colorThemes: IColorThemes = {
   autumnTheme: {
     primary: {
       nodeColor: '#ffffff',
-      textColor: 'rgb(0,0,0)',
+      textColor: '#000000',
       borderColor: '#F0F0F0',
       defaultOpacity: 60,
     },
     secondary: {
       nodeColor: '#471717',
-      textColor: 'rgb(255, 255, 255)',
+      textColor: '#FFFFFF',
       borderColor: '#none',
       defaultOpacity: 100,
     },
     tertiary: {
       nodeColor: '#D67A25',
-      textColor: 'rgb(255, 255, 255)',
+      textColor: '#FFFFFF',
       borderColor: '#none',
       defaultOpacity: 100,
     },
     Quaternary: {
       nodeColor: '#F6F1E3',
-      textColor: 'rgb(26,27,80)',
+      textColor: '#1A1B50',
       borderColor: '#none',
       defaultOpacity: 100,
     },
@@ -56,25 +56,25 @@ export const colorThemes: IColorThemes = {
   summerTheme: {
     primary: {
       nodeColor: '#ffffff',
-      textColor: 'rgb(0,0,0)',
+      textColor: '#000000',
       borderColor: '#F0F0F0',
       defaultOpacity: 60,
     },
     secondary: {
       nodeColor: '#174739',
-      textColor: 'rgb(255, 255, 255)',
+      textColor: '#FFFFFF',
       borderColor: '#none',
       defaultOpacity: 100,
     },
     tertiary: {
       nodeColor: '#28C14A',
-      textColor: 'rgb(255, 255, 255)',
+      textColor: '#FFFFFF',
       borderColor: '#none',
       defaultOpacity: 100,
     },
     Quaternary: {
       nodeColor: '#E3F6EE',
-      textColor: 'rgb(26,27,80)',
+      textColor: '#1A1B50',
       borderColor: '#none',
       defaultOpacity: 100,
     },
@@ -82,25 +82,25 @@ export const colorThemes: IColorThemes = {
   springTheme: {
     primary: {
       nodeColor: '#ffffff',
-      textColor: 'rgb(0,0,0)',
+      textColor: '#000000',
       borderColor: '#F0F0F0',
       defaultOpacity: 60,
     },
     secondary: {
       nodeColor: '#3B1747',
-      textColor: 'rgb(255, 255, 255)',
+      textColor: '#FFFFFF',
       borderColor: '#none',
       defaultOpacity: 100,
     },
     tertiary: {
       nodeColor: '#7827CA',
-      textColor: 'rgb(255, 255, 255)',
+      textColor: '#FFFFFF',
       borderColor: '#none',
       defaultOpacity: 100,
     },
     Quaternary: {
       nodeColor: '#E8E3F6',
-      textColor: 'rgb(26,27,80)',
+      textColor: '#1A1B50',
       borderColor: '#none',
       defaultOpacity: 100,
     },

--- a/src/typescript/roadmap_ref/utils.ts
+++ b/src/typescript/roadmap_ref/utils.ts
@@ -11,6 +11,7 @@ export function deepCopy(obj) {
 
 export function donsole(...args) {
   // @ts-ignore
+  // eslint-disable-next-line no-console
   console.log(deepCopy(...args));
 }
 
@@ -22,6 +23,6 @@ export function clipValue(str: string, length: number) {
 export function hexAddAlpha(hex: string, alpha: number) {
   alpha = Math.round(alpha * 255);
   const hexWithoutHash = hex.slice(1);
-  const hexWithAlpha = hexWithoutHash + alpha.toString(16);
+  const hexWithAlpha = hexWithoutHash + alpha.toString(16).padStart(2, '0');
   return `#${hexWithAlpha}`;
 }

--- a/src/typescript/roadmap_ref/utils.ts
+++ b/src/typescript/roadmap_ref/utils.ts
@@ -17,3 +17,11 @@ export function donsole(...args) {
 export function clipValue(str: string, length: number) {
   return str.slice(0, length);
 }
+
+// ? Color utils
+export function hexAddAlpha(hex: string, alpha: number) {
+  alpha = Math.round(alpha * 255);
+  const hexWithoutHash = hex.slice(1);
+  const hexWithAlpha = hexWithoutHash + alpha.toString(16);
+  return `#${hexWithAlpha}`;
+}


### PR DESCRIPTION
The pull request updates our color formatting. Commit fa11ecc fixes the hexAddAlpha function in utils.ts to return consistent two-digit alpha values. Commit da37787 switches our color format from RGB to hexadecimal, reducing errors, and adds a utility function hexAddAlpha to manage color opacity. The changes are applied across theme definitions and can be seen in 'ComponentsRenderer.tsx' and 'NodeRendererForeign.tsx'.