### PR TITLE
Fix image reference

### DIFF
--- a/src/components/roadmap/contextmenu/NodeContextMenu.tsx
+++ b/src/components/roadmap/contextmenu/NodeContextMenu.tsx
@@ -98,7 +98,7 @@ const NodeContextMenu = () => {
             >
               {actionIcon && (
                 <img
-                  src={actionIcon}
+                  src={actionIcon.src}
                   alt={`${actionName} Icon`}
                   className='w-5 h-5 mr-2'
                 />

--- a/src/components/roadmap/navbar-roadmap/parts/BackArrow.tsx
+++ b/src/components/roadmap/navbar-roadmap/parts/BackArrow.tsx
@@ -5,6 +5,7 @@ import { tailwindTransitionClass } from '@src/UI-library/tailwind-utils';
 const BackArrow = () => {
   return (
     <button
+      type='button'
       onClick={() => {
         window.onbeforeunload = null;
 
@@ -14,7 +15,7 @@ const BackArrow = () => {
           window.location.href = '/explore';
         }, 100);
       }}
-      className={`justify-start cursor-pointer flex ml-4 w-8 h-8 p-1 bg-white hover:bg-gray-200${tailwindTransitionClass}`}
+      className={`justify-start cursor-pointer flex ml-4 w-8 h-8 p-1 bg-white hover:bg-gray-200 ${tailwindTransitionClass}`}
     >
       <img
         draggable='false'

--- a/src/components/roadmap/pages-roadmap/tab-attachment/TabAttachmentView.tsx
+++ b/src/components/roadmap/pages-roadmap/tab-attachment/TabAttachmentView.tsx
@@ -17,6 +17,7 @@ import TitleComponentTab from '@components/roadmap/pages-roadmap/tab-attachment/
 import DescriptionComponentTab from '@components/roadmap/pages-roadmap/tab-attachment/components/DescriptionComponentTab';
 import LinkComponentTab from '@components/roadmap/pages-roadmap/tab-attachment/components/LinkComponentTab';
 import { usePressEsc } from '@hooks/usePressEsc';
+import closeSvg from '@assets/cross.svg';
 
 const TabAttachmentView = () => {
   const { nodeId } = useStore(selectedTabNode);
@@ -67,7 +68,7 @@ const TabAttachmentView = () => {
             className={`hover:bg-gray-200 ${tailwindTransitionClass}`}
           >
             <img
-              src='/src/frontend/src/assets/editor/close.svg'
+              src={closeSvg.src}
               className='w-8 h-8'
               alt='Close button for editor'
             />


### PR DESCRIPTION
Fixed image reference in the NodeContextMenu and TabAttachmentView components, added space in class string for the BackArrow component.