### PR TITLE
Update image source reference in ThemeDisplayer

### DIFF
--- a/src/components/roadmap/to-be-organized/about/components/ThemeDisplayer.tsx
+++ b/src/components/roadmap/to-be-organized/about/components/ThemeDisplayer.tsx
@@ -86,7 +86,7 @@ const ThemeDisplayer = ({
                     }}
                   >
                     <img
-                      src={theme.name}
+                      src={theme.name.src}
                       alt={`theme${theme.id + 1}`}
                       className='ml-5'
                     />

--- a/src/to-be-organized/node-rendering-stuff/NodeRendererClassic.tsx
+++ b/src/to-be-organized/node-rendering-stuff/NodeRendererClassic.tsx
@@ -33,6 +33,7 @@ import { showContextMenu } from '@components/roadmap/contextmenu/store/ContextMe
 import { setNotification } from '@components/roadmap/to-be-organized/notifications/notifciations-refr/notification-store-refr';
 import { checkIsMobile } from '@hooks/useIsMobile';
 import useContextMenuOrLongPress from '@hooks/useContextMenuOrLongPress';
+import { setRoadmapNodeProgressAndFetchUpdate } from '@store/roadmap-refactor/roadmap-data/misc-data/roadmap-progress';
 
 interface NodeViewProps {
   nodeId: string;
@@ -138,6 +139,8 @@ const NodeRendererClassic: React.FC<NodeViewProps> = ({
           top: `${centeredCoords.y}px`,
           left: `${centeredCoords.x}px`,
         }}
+        onBlur={() => {}}
+        onFocus={() => {}}
         onMouseOver={(event) => {
           event.stopPropagation();
           getOnMouseOverAction(nodeId)();


### PR DESCRIPTION
Changed the reference for the theme image source in ThemeDisplayer component from 'theme.name' to 'theme.name.src'. This fixes a bug where image failed to load due to incorrect reference. Also, imported 'setRoadmapNodeProgressAndFetchUpdate' in NodeRendererClassic to fix missing function import issue.