### PR TITLE
Add max-width to mobile roadmap cards

### DIFF
--- a/src/components/home/mobile/sections/why-roadmaps/components/CardsM.tsx
+++ b/src/components/home/mobile/sections/why-roadmaps/components/CardsM.tsx
@@ -29,7 +29,7 @@ const CardsM = ({
   const imagePath = imageMap[image];
   return (
     <motion.div
-      className='border-primary border-t-4 w-full h-60 px-6 bg-white drop-shadow-md items-center'
+      className='border-primary border-t-4 w-full max-w-sm h-60 px-6 bg-white drop-shadow-md items-center'
       // initial='hidden'
       // animate={animate}
       // variants={variants}


### PR DESCRIPTION
This change was necessary to prevent the cards from stretching too wide on larger mobile screens and affecting the aesthetics and readability of the content.