### PR TITLE
Correct position of node status bar.

### DIFF
--- a/src/to-be-organized/node-rendering-stuff/NodeRendererClassic.tsx
+++ b/src/to-be-organized/node-rendering-stuff/NodeRendererClassic.tsx
@@ -241,7 +241,7 @@ const NodeRendererClassic: React.FC<NodeViewProps> = ({
           !getHideProgress() &&
           node.actions.onClick !== 'Do nothing' && (
             <div
-              className={`h-[10px] left-[-2px] top-[-2px] rounded-t-md absolute select-none ${getNodeStatusBarColor(
+              className={`h-[10px] left-0 top-0 rounded-t-md absolute select-none ${getNodeStatusBarColor(
                 node
               )}`}
               style={{


### PR DESCRIPTION
The change was made to ensure the node status bar is positioned properly. Previously, negative values were used for left and top CSS properties which caused mispositioning of the status bar. Those have been corrected to zero for proper aligning.