### PR TITLE
Corrected offset value in NodesAnimation component

### DIFF
--- a/src/components/home/desktop/components/NodesAnimation.tsx
+++ b/src/components/home/desktop/components/NodesAnimation.tsx
@@ -72,7 +72,7 @@ const NodesAnimation = ({
         >
           <stop offset='0%' stopColor='#3361D8' stopOpacity={1} />
           <stop
-            offset={isStraight ? '-%' : '60%'}
+            offset={isStraight ? '0%' : '60%'}
             stopColor='#3361D8'
             stopOpacity={isStraight ? 0 : 1}
           />


### PR DESCRIPTION
NodesAnimation component was incorrectly set to '-%' for 'isStraight' offset value. It's illogical to have offset value in non-number percentage, so it has been changed to '0%'. This fixes the issue of inconsistent animation being displayed when 'isStraight' is true.