### PR TITLE
HOTFIX: incorrect href in roadmap creation button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "navigolearn-front",
-  "version": "2.1.1HOTFIX1",
+  "version": "2.1.1HOTFIX2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "navigolearn-front",
-      "version": "2.1.1HOTFIX1",
+      "version": "2.1.1HOTFIX2",
       "license": "BSD 3-Clause",
       "dependencies": {
         "@astrojs/node": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "navigolearn-front",
   "type": "module",
-  "version": "2.1.1HOTFIX1",
+  "version": "2.1.1HOTFIX2",
   "description": "Navigo Front End",
   "repository": "https://github.com/NavigoLearn/Navigo-FrontEnd.git",
   "author": "Navigo",

--- a/src/components/home/desktop/HomeDesktop.tsx
+++ b/src/components/home/desktop/HomeDesktop.tsx
@@ -33,7 +33,7 @@ const HomeDesktop = () => {
         <div className='mt-2 w-[500px] mx-auto gap-2 flex flex-row'>
           <motion.a
             type='button'
-            href='/roadmaps/create'
+            href='/roadmap/create'
             className='mx-auto mt-8 px-5 py-2 text-darkBlue bg-transparent rounded-lg shadow-md text-xl font-roboto-text font-semibold border-2 border-darkBlue'
             whileHover={{
               backgroundColor: '#1A1B50',

--- a/src/components/home/desktop/sections/EditorSection.tsx
+++ b/src/components/home/desktop/sections/EditorSection.tsx
@@ -72,7 +72,7 @@ const EditorSection = (stateProps: BottomSectionStateProps) => {
         </p>
         <motion.a
           type='button'
-          href='/roadmaps/create'
+          href='/roadmap/create'
           className='mt-8 bg-primary text-white font-roboto-text font-medium text-xl px-10 py-1 rounded-md shadow-md'
           whileHover={{
             backgroundColor: '#1A1B50',

--- a/src/components/home/desktop/sections/ScrollingElement.tsx
+++ b/src/components/home/desktop/sections/ScrollingElement.tsx
@@ -89,7 +89,7 @@ const ScrollingElement = () => {
           >
             <motion.a
               type='button'
-              href='/roadmaps/create'
+              href='/roadmap/create'
               className=' px-5 py-2 text-darkBlue bg-transparent rounded-md shadow-md text-md font-roboto-text font-semibold border-2 border-darkBlue'
               whileHover={{
                 backgroundColor: '#1A1B50',


### PR DESCRIPTION
The href of the roadmap creation button was incorrect, causing a failed redirection when the button is clicked. The url '/roadmaps/create' has been corrected to '/roadmap/create' in ScrollingElement.tsx, EditorSection.tsx and HomeDesktop.tsx.